### PR TITLE
Resolve issue with SonarCloud buildConfiguration variable reference

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,7 +12,6 @@
 name: "CodeQL"
 
 on:
-  workflow_dispatch:
   push:
     branches: [ main, develop ]
     paths-ignore:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,7 @@
 name: "CodeQL"
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main, develop ]
     paths-ignore:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,7 +1,6 @@
 name: Build and Test
 
 on:
-  workflow_dispatch:
   push:
     branches: [ main, develop ]
     paths-ignore:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,6 +1,7 @@
 name: Build and Test
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main, develop ]
     paths-ignore:

--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -74,5 +74,5 @@ jobs:
         shell: powershell
         run: |
           .\.sonar\scanner\dotnet-sonarscanner begin /k:"ConsumerDataRight_mock-solution-test-automation" /o:"consumerdataright" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
-          dotnet build .\Source\ConsumerDataRight.ParticipantTooling.MockSolution.TestAutomation.sln --configuration {{ env.buildConfiguration }} -p:UsingGitHubSource=true
+          dotnet build .\Source\ConsumerDataRight.ParticipantTooling.MockSolution.TestAutomation.sln --configuration $env.buildConfiguration -p:UsingGitHubSource=true
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -1,5 +1,6 @@
 name: SonarCloud
 on:
+  workflow_dispatch:
   push:
     branches:  [main, develop]
     paths-ignore:

--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -1,6 +1,5 @@
 name: SonarCloud
 on:
-  workflow_dispatch:
   push:
     branches:  [main, develop]
     paths-ignore:

--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -74,5 +74,5 @@ jobs:
         shell: powershell
         run: |
           .\.sonar\scanner\dotnet-sonarscanner begin /k:"ConsumerDataRight_mock-solution-test-automation" /o:"consumerdataright" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
-          dotnet build .\Source\ConsumerDataRight.ParticipantTooling.MockSolution.TestAutomation.sln --configuration $buildConfiguration -p:UsingGitHubSource=true
+          dotnet build .\Source\ConsumerDataRight.ParticipantTooling.MockSolution.TestAutomation.sln --configuration {{ env.buildConfiguration }} -p:UsingGitHubSource=true
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -74,5 +74,5 @@ jobs:
         shell: powershell
         run: |
           .\.sonar\scanner\dotnet-sonarscanner begin /k:"ConsumerDataRight_mock-solution-test-automation" /o:"consumerdataright" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
-          dotnet build .\Source\ConsumerDataRight.ParticipantTooling.MockSolution.TestAutomation.sln --configuration $env.buildConfiguration -p:UsingGitHubSource=true
+          dotnet build .\Source\ConsumerDataRight.ParticipantTooling.MockSolution.TestAutomation.sln --configuration ${{ env.buildConfiguration }} -p:UsingGitHubSource=true
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"


### PR DESCRIPTION
**Checklist:** (Put an `x` in all the boxes that apply)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have checked that there aren't any other open **Pull Requests** from the same change.
- [x] The `develop` branch has been set as the `base` branch to merge changes of the pull request.
- [ ] I have updated the `CHANGELOG.md` file as appropriate.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


**What is the current behavior?** (You can also link to an open issue here)
The Sonarcloud Github action fails due to incorrect variable reference in dotnet build command


**What is the new behavior?** (if this is a feature change)
The Sonarcloud Github action will run successfully.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
